### PR TITLE
Fallback to old behaviour for org ID

### DIFF
--- a/shiftleft-utils/export.py
+++ b/shiftleft-utils/export.py
@@ -330,7 +330,7 @@ def extract_org_id(token):
             return orgID
     except:
         print("Unable to parse the environment variable SHIFTLEFT_ACCESS_TOKEN")
-    return None
+    return os.getenv("SHIFTLEFT_ORG_ID")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In case org ID cannot be inferred from access token, fallback to the old
behaviour. Not recommended, so also not documented.