### PR TITLE
api config and stop pagination if the API returns non-200 response

### DIFF
--- a/shiftleft-utils/common.py
+++ b/shiftleft-utils/common.py
@@ -3,6 +3,8 @@ import os
 
 import jwt
 import requests
+import urllib.parse
+
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.progress import Progress
@@ -98,10 +100,12 @@ def get_all_findings(org_id, app_name, version):
                         task, total=total_count, completed=len(findings_list)
                     )
                     if raw_response.get("next_page"):
-                        findings_url = raw_response.get("next_page")
+                        parsed = urllib.parse.urlparse(raw_response.get("next_page"))
+                        findings_url = parsed._replace(netloc=config.SHIFTLEFT_API_HOST).geturl()
                     else:
                         page_available = False
             else:
+                page_available = False
                 print(f"Unable to retrieve findings for {app_name}")
                 print(r.status_code, r.json())
         progress.stop()

--- a/shiftleft-utils/common.py
+++ b/shiftleft-utils/common.py
@@ -40,12 +40,12 @@ headers = {
 
 def get_findings_url(org_id, app_name, version):
     version_suffix = f"&version={version}" if version else ""
-    return f"https://www.shiftleft.io/api/v4/orgs/{org_id}/apps/{app_name}/findings?per_page=249&type=secret&type=vuln&type=extscan&include_dataflows=true{version_suffix}"
+    return f"https://{config.SHIFTLEFT_API_HOST}/api/v4/orgs/{org_id}/apps/{app_name}/findings?per_page=249&type=secret&type=vuln&type=extscan&include_dataflows=true{version_suffix}"
 
 
 def get_all_apps(org_id):
     """Return all the apps for the given organization"""
-    list_apps_url = f"https://www.shiftleft.io/api/v4/orgs/{org_id}/apps"
+    list_apps_url = f"https://{config.SHIFTLEFT_API_HOST}/api/v4/orgs/{org_id}/apps"
     r = requests.get(list_apps_url, headers=headers)
     if r.ok:
         raw_response = r.json()
@@ -109,7 +109,7 @@ def get_all_findings(org_id, app_name, version):
 
 
 def get_dataflow(org_id, app_name, finding_id):
-    finding_url = f"https://www.shiftleft.io/api/v4/orgs/{org_id}/apps/{app_name}/findings/{finding_id}?include_dataflows=true"
+    finding_url = f"https://{config.SHIFTLEFT_API_HOST}/api/v4/orgs/{org_id}/apps/{app_name}/findings/{finding_id}?include_dataflows=true"
     r = requests.get(finding_url, headers=headers)
     if r.ok:
         raw_response = r.json()

--- a/shiftleft-utils/config.py
+++ b/shiftleft-utils/config.py
@@ -2,6 +2,7 @@ import os
 
 SHIFTLEFT_ACCESS_TOKEN = os.getenv("SHIFTLEFT_ACCESS_TOKEN")
 SHIFTLEFT_APP = os.getenv("SHIFTLEFT_APP")
+SHIFTLEFT_API_HOST = os.getenv("SHIFTLEFT_API_HOST") or "www.shiftleft.io"
 
 # Indentation for json. Set to None to disable indendation
 json_indent = 2

--- a/shiftleft-utils/export.py
+++ b/shiftleft-utils/export.py
@@ -133,6 +133,7 @@ def get_all_findings(org_id, app_name, version):
                 else:
                     page_available = False
         else:
+            page_available = False
             print(f"Unable to retrieve findings for {app_name}")
             print(r.status_code, r.json())
     return findings_list

--- a/shiftleft-utils/export.py
+++ b/shiftleft-utils/export.py
@@ -5,6 +5,7 @@ import csv
 import json
 import os
 import requests
+import urllib.parse
 import sys
 import time
 
@@ -129,7 +130,8 @@ def get_all_findings(org_id, app_name, version):
                 counts = response.get("counts")
                 findings_list += findings
                 if raw_response.get("next_page"):
-                    findings_url = raw_response.get("next_page")
+                    parsed = urllib.parse.urlparse(raw_response.get("next_page"))
+                    findings_url = parsed._replace(netloc=config.SHIFTLEFT_API_HOST).geturl()
                 else:
                     page_available = False
         else:


### PR DESCRIPTION
This PR does two things:

### fail fast on finding pagination
If the org or project do not exist (404), this script can make many requests...

### make api host config
we need to be able to set SHIFTLEFT_API_HOST so we can test on staging