### PR TITLE
OWASP export: use CWEs instead of (outdated) category names

### DIFF
--- a/shiftleft-utils/config.py
+++ b/shiftleft-utils/config.py
@@ -17,20 +17,17 @@ ngsast_logo = """
 """
 
 # This is WIP
+
 sl_owasp_category = {
-    "SQL Injection": "sqli",
-    "LDAP Injection": "ldapi",
-    "XPath Injection": "xpathi",
-    "Weak Random": "weakrand",
-    "Session Injection": "trustbound",
-    "Cookie Injection": "securecookie",
-    "Weak Hash": "hash",
-    "hash": "hash",
-    "Open Redirect": "pathtraver",
-    "XSS": "xss",
-    "Remote Code Execution": "cmdi",
-    "Insecure Cookie": "securecookie",
-    "Directory Traversal": "pathtraver",
-    "Broken Authentication": "crypto",
-    "Weak symmetric encryption algorithm": "crypto",
+    78: "cmdi",
+    327: "crypto",
+    328: "hash",
+    90: "ldapi",
+    22: "pathtraver",
+    614: "securecookie",
+    89: "sqli",
+    501: "trustbound",
+    330: "weakrand",
+    643: "xpathi",
+    79: "xss",
 }

--- a/shiftleft-utils/export.py
+++ b/shiftleft-utils/export.py
@@ -257,25 +257,16 @@ def export_report(org_id, app_list, report_file, format):
                                 f"Unable to extract filename from file_locations or title {title}. Skipping ..."
                             )
                             continue
-                        tags = af.get("tags")
-                        cwe_id = ""
-                        category = af.get("title")
-                        for tag in tags:
-                            if tag["key"] == "category":
-                                category = tag["value"]
-                            if tag["key"] == "cwe_category":
-                                cwe_id = tag["value"]
-                        if not category and cwe_id == "384":
-                            category = "Broken Authentication"
-                        if config.sl_owasp_category.get(category):
-                            category = config.sl_owasp_category.get(category)
-                        file_category = f"{filename},{category}"
-                        if (
-                            " " not in category
-                            and file_category not in file_category_set
-                        ):
-                            rp.write(file_category + "\n")
-                            file_category_set.add(file_category)
+                        cwes = (int(pair['value']) for pair in af['tags'] if pair['key'] == 'cwe_category')
+                        categories = (config.sl_owasp_category[cwe] for cwe in cwes if cwe in config.sl_owasp_category)
+                        try:
+                            category = next(categories)
+                            file_category = f"{filename},{category}"
+                            if file_category not in file_category_set:
+                                rp.write(file_category + "\n")
+                                file_category_set.add(file_category)
+                        except StopIteration:
+                            pass
                     progress.console.print(
                         f"Findings report successfully exported to {report_file}"
                     )


### PR DESCRIPTION
some category names have changed and broke this script. I'm switching this to CWEs since I expect them to change less often. (But I changed the CWEs to exactly match the benchmark in preparation of this change - so right now this only works on staging. I'll wait for a release before pressing the merge button.)