### PR TITLE
Initializing low_findings_count to False to prevent UnboundLocalError

### DIFF
--- a/shiftleft-utils/bestfix.py
+++ b/shiftleft-utils/bestfix.py
@@ -598,6 +598,7 @@ def troubleshoot_app(
                 "metadata_file_name"
             ):
                 remediation_used = True
+    low_findings_count = False
     if sizes:
         files = sizes.get("files", 0)
         lines = sizes.get("lines", 0)


### PR DESCRIPTION
Initializing low_findings_count to False to prevent UnboundLocalError