### PR TITLE
Fixed code when sbom list is less than 100

### DIFF
--- a/shiftleft-utils/sbom_report.py
+++ b/shiftleft-utils/sbom_report.py
@@ -61,7 +61,7 @@ def get_sca_packages(org_id, app_id):
         console.print(
             f"Retrieved {packages_count} SCA packages for {app_id}"
         )
-        raw_response.pop("has_more")
+        raw_response.pop("has_more", None)
         return raw_response
     else:
         console.print(


### PR DESCRIPTION
When sbom count is less than 100, I get this error .  [https://app.shiftleft.io/api/v4/orgs/{{orgID}}/apps/{{appID}}/sca/packages?page=1&per_page=100 does not have "has_more" element and hence the pop statement is failing as this element is not found on the dictionary